### PR TITLE
Feature: universities-service

### DIFF
--- a/src/shared/models/universityOverviewsModel.ts
+++ b/src/shared/models/universityOverviewsModel.ts
@@ -1,0 +1,6 @@
+export interface  SB_UniversityOverviews{
+    id: string;
+    comment: string;
+    profile_id: string;
+    university_id: string;
+}

--- a/src/shared/services/universityOverviewsService.ts
+++ b/src/shared/services/universityOverviewsService.ts
@@ -1,0 +1,64 @@
+import supabase from "../../config/supabase/supabase";
+import type { SB_UniversityOverviews } from "../models/universityOverviewsModel";
+
+
+export const getAllUniversityOverviews = async (): Promise<SB_UniversityOverviews[]> => {
+  const { data, error } = await supabase
+    .from("university_overviews")
+    .select("*");
+
+  if (error) throw new Error(error.message);
+  return data as SB_UniversityOverviews[];
+};
+
+
+export const getUniversityOverviewById = async (id: number): Promise<SB_UniversityOverviews> => {
+  const { data, error } = await supabase
+    .from("university_overviews")
+    .select("*")
+    .eq("id", id)
+    .single();
+
+  if (error) throw new Error(error.message);
+  return data as SB_UniversityOverviews;
+};
+
+
+export const createUniversityOverview = async (
+  payload: Omit<SB_UniversityOverviews, "id">
+): Promise<SB_UniversityOverviews> => {
+  const { data, error } = await supabase
+    .from("university_overviews")
+    .insert(payload)
+    .select()
+    .single();
+
+  if (error) throw new Error(error.message);
+  return data as SB_UniversityOverviews;
+};
+
+
+export const updateUniversityOverview = async (
+  id: number,
+  payload: Partial<Omit<SB_UniversityOverviews, "id">>
+): Promise<SB_UniversityOverviews> => {
+  const { data, error } = await supabase
+    .from("university_overviews")
+    .update(payload)
+    .eq("id", id)
+    .select()
+    .single();
+
+  if (error) throw new Error(error.message);
+  return data as SB_UniversityOverviews;
+};
+
+
+export const deleteUniversityOverview = async (id: string): Promise<void> => {
+  const { error } = await supabase
+    .from("university_overviews")
+    .delete()
+    .eq("id", id);
+
+  if (error) throw new Error(error.message);
+};

--- a/src/shared/services/universityService.ts
+++ b/src/shared/services/universityService.ts
@@ -1,0 +1,26 @@
+import supabase from "../../config/supabase/supabase";
+
+export const getAllUniversities = async() => {
+    const { data, error } = await supabase
+    .from("universities")
+    .select("*");
+
+    if(!data) throw new Error(`No se pudo obtener los datos`);
+    if(error) throw new Error(`Hubo un error obteniendos los datos ${error}`)
+    
+    return data || [];
+}
+
+
+export const getUniversityFullDetail = async(universityId: string) =>{
+    const { data, error } = await supabase
+    .rpc(
+        'get_university_full_detail',
+        { p_university_id: universityId}
+    );
+    
+    if(!data) throw new Error(`No se pudo obtener los datos`);
+    if(error) throw new Error(`Hubo un error obteniendos los datos ${error.message}`)
+    
+    return data;
+}

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,11 +1,13 @@
 import { configureStore } from '@reduxjs/toolkit';
 import authReducer from './auth/authSlice';
 import documeReducer from './document/documentSlice';
+import universityReducer from './university/universitySlice';
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
     document: documeReducer,
+    university: universityReducer,
   },
 });
 

--- a/src/store/university/thunks.ts
+++ b/src/store/university/thunks.ts
@@ -1,0 +1,93 @@
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import { getAllUniversities, getUniversityFullDetail } from "../../shared/services/universityService";
+import {
+  getAllUniversityOverviews,
+  getUniversityOverviewById,
+  createUniversityOverview,
+  updateUniversityOverview,
+  deleteUniversityOverview,
+} from "../../shared/services/universityOverviewsService";
+import type { SB_UniversityOverviews } from "../../shared/models/universityOverviewsModel";
+
+
+export const fetchAllUniversitiesThunk = createAsyncThunk(
+  "universities/fetchAll",
+  async (_, { rejectWithValue }) => {
+    try {
+      return await getAllUniversities();
+    } catch (error) {
+      return rejectWithValue((error as Error).message);
+    }
+  }
+);
+
+export const fetchUniversityFullDetailThunk = createAsyncThunk(
+  "universities/fetchFullDetail",
+  async (universityId: string, { rejectWithValue }) => {
+    try {
+      return await getUniversityFullDetail(universityId);
+    } catch (error) {
+      return rejectWithValue((error as Error).message);
+    }
+  }
+);
+
+
+export const fetchAllUniversityOverviewsThunk = createAsyncThunk(
+  "universityOverviews/fetchAll",
+  async (_, { rejectWithValue }) => {
+    try {
+      return await getAllUniversityOverviews();
+    } catch (error) {
+      return rejectWithValue((error as Error).message);
+    }
+  }
+);
+
+export const fetchUniversityOverviewByIdThunk = createAsyncThunk(
+  "universityOverviews/fetchById",
+  async (id: number, { rejectWithValue }) => {
+    try {
+      return await getUniversityOverviewById(id);
+    } catch (error) {
+      return rejectWithValue((error as Error).message);
+    }
+  }
+);
+
+export const createUniversityOverviewThunk = createAsyncThunk(
+  "universityOverviews/create",
+  async (payload: Omit<SB_UniversityOverviews, "id">, { rejectWithValue }) => {
+    try {
+      return await createUniversityOverview(payload);
+    } catch (error) {
+      return rejectWithValue((error as Error).message);
+    }
+  }
+);
+
+export const updateUniversityOverviewThunk = createAsyncThunk(
+  "universityOverviews/update",
+  async (
+    { id, payload }: { id: number; payload: Partial<Omit<SB_UniversityOverviews, "id">> },
+    { rejectWithValue }
+  ) => {
+    try {
+      return await updateUniversityOverview(id, payload);
+    } catch (error) {
+      return rejectWithValue((error as Error).message);
+    }
+  }
+);
+
+export const deleteUniversityOverviewThunk = createAsyncThunk(
+  "universityOverviews/delete",
+  async (id: string, { rejectWithValue }) => {
+    try {
+      await deleteUniversityOverview(id);
+      return id;
+    } catch (error) {
+      return rejectWithValue((error as Error).message);
+    }
+  }
+);

--- a/src/store/university/universitySlice.ts
+++ b/src/store/university/universitySlice.ts
@@ -1,0 +1,140 @@
+import { createSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import type { SB_UniversityOverviews } from '../../shared/models/universityOverviewsModel';
+import {
+    fetchAllUniversitiesThunk,
+    fetchUniversityFullDetailThunk,
+    fetchAllUniversityOverviewsThunk,
+    fetchUniversityOverviewByIdThunk,
+    createUniversityOverviewThunk,
+    updateUniversityOverviewThunk,
+    deleteUniversityOverviewThunk,
+} from './thunks';
+
+export interface UniversityState {
+    universities: any[];
+    universityDetail: any | null;
+    overviews: SB_UniversityOverviews[];
+    selectedOverview: SB_UniversityOverviews | null;
+    status: 'idle' | 'pending' | 'success' | 'failed';
+    error: string | null;
+}
+
+const initialState: UniversityState = {
+    universities: [],
+    universityDetail: null,
+    overviews: [],
+    selectedOverview: null,
+    status: 'idle',
+    error: null,
+};
+
+const universitySlice = createSlice({
+    name: 'university',
+    initialState,
+    reducers: {
+        clearUniversityDetail: (state) => {
+            state.universityDetail = null;
+        },
+        clearSelectedOverview: (state) => {
+            state.selectedOverview = null;
+        },
+    },
+    extraReducers: (builder) => {
+        builder
+            .addCase(fetchAllUniversitiesThunk.pending, (state) => {
+                state.status = 'pending';
+                state.error = null;
+            })
+            .addCase(fetchAllUniversitiesThunk.fulfilled, (state, action: PayloadAction<any[]>) => {
+                state.status = 'success';
+                state.universities = action.payload;
+            })
+            .addCase(fetchAllUniversitiesThunk.rejected, (state, action) => {
+                state.status = 'failed';
+                state.error = action.payload as string ?? 'Error al obtener las universidades.';
+            })
+
+            .addCase(fetchUniversityFullDetailThunk.pending, (state) => {
+                state.status = 'pending';
+                state.error = null;
+            })
+            .addCase(fetchUniversityFullDetailThunk.fulfilled, (state, action: PayloadAction<any>) => {
+                state.status = 'success';
+                state.universityDetail = action.payload;
+            })
+            .addCase(fetchUniversityFullDetailThunk.rejected, (state, action) => {
+                state.status = 'failed';
+                state.error = action.payload as string ?? 'Error al obtener el detalle de la universidad.';
+            })
+
+            .addCase(fetchAllUniversityOverviewsThunk.pending, (state) => {
+                state.status = 'pending';
+                state.error = null;
+            })
+            .addCase(fetchAllUniversityOverviewsThunk.fulfilled, (state, action: PayloadAction<SB_UniversityOverviews[]>) => {
+                state.status = 'success';
+                state.overviews = action.payload;
+            })
+            .addCase(fetchAllUniversityOverviewsThunk.rejected, (state, action) => {
+                state.status = 'failed';
+                state.error = action.payload as string ?? 'Error al obtener los overviews.';
+            })
+
+            .addCase(fetchUniversityOverviewByIdThunk.pending, (state) => {
+                state.status = 'pending';
+                state.error = null;
+            })
+            .addCase(fetchUniversityOverviewByIdThunk.fulfilled, (state, action: PayloadAction<SB_UniversityOverviews>) => {
+                state.status = 'success';
+                state.selectedOverview = action.payload;
+            })
+            .addCase(fetchUniversityOverviewByIdThunk.rejected, (state, action) => {
+                state.status = 'failed';
+                state.error = action.payload as string ?? 'Error al obtener el overview.';
+            })
+
+            .addCase(createUniversityOverviewThunk.pending, (state) => {
+                state.status = 'pending';
+                state.error = null;
+            })
+            .addCase(createUniversityOverviewThunk.fulfilled, (state, action: PayloadAction<SB_UniversityOverviews>) => {
+                state.status = 'success';
+                state.overviews.push(action.payload);
+            })
+            .addCase(createUniversityOverviewThunk.rejected, (state, action) => {
+                state.status = 'failed';
+                state.error = action.payload as string ?? 'Error al crear el overview.';
+            })
+
+            .addCase(updateUniversityOverviewThunk.pending, (state) => {
+                state.status = 'pending';
+                state.error = null;
+            })
+            .addCase(updateUniversityOverviewThunk.fulfilled, (state, action: PayloadAction<SB_UniversityOverviews>) => {
+                state.status = 'success';
+                const index = state.overviews.findIndex((ov) => ov.id === action.payload.id);
+                if (index !== -1) state.overviews[index] = action.payload;
+            })
+            .addCase(updateUniversityOverviewThunk.rejected, (state, action) => {
+                state.status = 'failed';
+                state.error = action.payload as string ?? 'Error al actualizar el overview.';
+            })
+
+            .addCase(deleteUniversityOverviewThunk.pending, (state) => {
+                state.status = 'pending';
+                state.error = null;
+            })
+            .addCase(deleteUniversityOverviewThunk.fulfilled, (state, action: PayloadAction<string>) => {
+                state.status = 'success';
+                state.overviews = state.overviews.filter((ov) => ov.id !== action.payload);
+            })
+            .addCase(deleteUniversityOverviewThunk.rejected, (state, action) => {
+                state.status = 'failed';
+                state.error = action.payload as string ?? 'Error al eliminar el overview.';
+            });
+    },
+});
+
+export const { clearUniversityDetail, clearSelectedOverview } = universitySlice.actions;
+export default universitySlice.reducer;


### PR DESCRIPTION
# Pull Request - UniPath (Front-End)

## 📝 Descripción
Se crearon los servicios, thunks y slice para gestionar las universidades y las reseñas (overviews) de los estudiantes, incluyendo operaciones CRUD completas y la integración con la función RPC de Supabase para obtener el detalle completo de una universidad.

## 🎯 Tipo de cambio
- [x] Nueva funcionalidad (feature)
- [ ] Corrección de bug (bugfix)
- [ ] Refactorización
- [ ] Actualización de documentación

## 🔗 Tarea de Notion
[Link de la tarea](https://www.notion.so/yeremypf/Query-detalle-universidad-con-rese-as-y-requerimientos-3355be864edc80cb9c29d313f6d8a29f?source=copy_link)

## ✅ Cambios realizados
- Creación del servicio `universityService.ts` con `getAllUniversities` y `getUniversityFullDetail` (vía RPC de Supabase)
- Creación del servicio `universityOverviewsService.ts` con CRUD completo para la tabla `university_overviews`
- Creación de los thunks en `thunks.ts` para todas las operaciones de universidades y overviews
- Creación del slice `universitySlice.ts` con estado para `universities`, `universityDetail`, `overviews` y `selectedOverview`

## 📌 Notas adicionales
- El tipo de `universities` y `universityDetail` en el slice está definido como `any` temporalmente hasta que se defina el modelo `SB_University`.