### PR TITLE
Feature: implement best message on gemini answer

### DIFF
--- a/src/pages/application-documents/components/DocumentRecommendationCard.tsx
+++ b/src/pages/application-documents/components/DocumentRecommendationCard.tsx
@@ -33,6 +33,27 @@ const parseAnswer = (raw: string): Section[] => {
     current = null;
   };
 
+  const itemPatterns = [
+    /^- (.+)/,
+    /^\* (.+)/,
+    /^(\d+[\.\)]\s*)(.+)/,
+    /^[-*]\s+\*\*(.+?)\*\*(.*)/,
+  ];
+
+  const isInvalidDocText = (text: string): boolean => {
+    const lower = text.toLowerCase();
+    return (
+      lower.includes('el documento que subiste') ||
+      lower.includes('no corresponde a ninguno') ||
+      lower.includes('no es válido') ||
+      lower.includes('no está contemplado') ||
+      lower.includes('ticket_') ||
+      /\.png$/i.test(text) ||
+      /\.jpg$/i.test(text) ||
+      /\.pdf$/i.test(text)
+    );
+  };
+
   for (const line of lines) {
     const trimmed = line.trim();
     if (!trimmed) continue;
@@ -40,26 +61,47 @@ const parseAnswer = (raw: string): Section[] => {
     if (trimmed.startsWith('**') && trimmed.endsWith('**')) {
       flush();
       const title = trimmed.replace(/\*\*/g, '');
-      const isMissing = title.toLowerCase().includes('faltante');
+      const isDocumentsMissing = title.toLowerCase().includes('documentos faltantes') ||
+                                 title.toLowerCase().includes('documentos que faltan');
+      const isEstadoGeneral = title.toLowerCase().includes('estado general');
       const isText =
         title.toLowerCase().includes('recomendaci') ||
         title.toLowerCase().includes('nota');
 
+      let sectionType: SectionType = 'list';
+      if (isDocumentsMissing) {
+        sectionType = 'chips';
+      } else if (isEstadoGeneral) {
+        sectionType = 'text';
+      } else if (isText) {
+        sectionType = 'text';
+      }
+
       current = {
-        type: isMissing ? 'chips' : isText ? 'text' : 'list',
+        type: sectionType,
         title,
         items: [],
       };
       continue;
     }
 
-    if (trimmed.startsWith('-') && current) {
-      const item = trimmed.replace(/^-\s*/, '').replace(/\*\*/g, '');
-      current.items = [...(current.items ?? []), item];
-      continue;
+    let matched = false;
+    for (const pattern of itemPatterns) {
+      const match = trimmed.match(pattern);
+      if (match) {
+        const item = match[match.length - 1].replace(/\*\*/g, '').trim();
+        if (item && current) {
+          current.items = [...(current.items ?? []), item];
+          matched = true;
+          break;
+        }
+      }
     }
 
-    if (trimmed && current) {
+    if (!matched && trimmed && current) {
+      if (current.type === 'chips' && isInvalidDocText(trimmed)) {
+        continue;
+      }
       textBuffer.push(trimmed);
     }
   }
@@ -142,6 +184,10 @@ export const DocumentRecommendationCard = ({
               </div>
             )}
 
+            {section.type === 'chips' && section.text && (
+              <p className="text-gray-700 leading-relaxed mt-2">{section.text}</p>
+            )}
+
             {section.type === 'list' && (section.items?.length ?? 0) > 0 && (
               <ul className="list-disc list-inside space-y-1 text-gray-700">
                 {section.items!.map((item, j) => (
@@ -152,6 +198,14 @@ export const DocumentRecommendationCard = ({
 
             {section.type === 'text' && section.text && (
               <p className="text-gray-700 leading-relaxed">{section.text}</p>
+            )}
+
+            {section.type === 'text' && (section.items?.length ?? 0) > 0 && (
+              <ul className="list-disc list-inside space-y-1 text-gray-700">
+                {section.items!.map((item, j) => (
+                  <li key={j}>{item}</li>
+                ))}
+              </ul>
             )}
           </div>
         ))}


### PR DESCRIPTION
# Pull Request - UniPath (Front-End)

## 📝 Descripción
Se mejoró el parsing de la respuesta de la IA en el componente DocumentRecommendationCard para manejar correctamente los diferentes tipos de secciones generadas por la función document_recommender. Ahora las secciones "Documentos faltantes", "Estado general" y "Recomendación" se renderizan apropiadamente según su tipo de contenido.

## 🎯 Tipo de cambio
- [ ] Nueva funcionalidad (feature)
- [x] Corrección de bug (bugfix)
- [ ] Refactorización
- [ ] Actualización de documentación

## 🔗 Tarea de Notion
none

## ✅ Cambios realizados
- Separación de detección de secciones: "Documentos faltantes" ahora se renderiza como chips (badges), mientras que "Estado general" y "Recomendación" se renderizan como texto
- Mejora de patrones de parsing para capturar items en diferentes formatos: guiones (-), asteriscos (*), números (1. / 1)), y guiones con negrita (**)
- Agregada función isInvalidDocText() para filtrar automáticamente el texto sobre documentos no válidos que no corresponde a ningún requisito (ej: "El documento que subiste no corresponde a...")
- Mejorado el renderizado para mostrar tanto items como texto en secciones de tipo chips y text
- Detección específica de títulos: "documentos faltantes", "documentos que faltan", "estado general", "recomendación", "nota"

## 🧪 Pruebas realizadas
- Prueba manual con respuesta simulada de la IA conteniendo las tres secciones esperadas
- Verificación de que los documentos faltantes se muestran como chips (badges ámbar)
- Verificación de que "Estado general" se muestra como texto descriptivo
- Verificación de que el texto sobre documentos inválidos no se muestra en la interfaz

## 📸 Screenshots

<img width="871" height="479" alt="image" src="https://github.com/user-attachments/assets/07932101-f9c7-48d5-bbb5-58adfda410f9" />


## 📌 Notas adicionales
- Los cambios son retrocompatibles con respuestas existentes de la IA que usen el formato esperado del prompt
- El filtrado de documentos inválidos usa patrones específicos para evitar mostrar información confusa al usuario sobre documentos que no cumplen requisitos
- No se modificó la sección "Documentos faltante" existente, solo se ajustó el parsing